### PR TITLE
Use 60 seconds default keepalive setting

### DIFF
--- a/umqtt/simple.py
+++ b/umqtt/simple.py
@@ -15,7 +15,7 @@ class MQTTClient:
         port=0,
         user=None,
         password=None,
-        keepalive=0,
+        keepalive=60,
         ssl=False,
         ssl_params={},
     ):

--- a/umqtt/universal.py
+++ b/umqtt/universal.py
@@ -7,7 +7,7 @@ class MQTTException(Exception):
 
 class MQTTClient:
 
-    def __init__(self, client_id, server, port=0, user=None, password=None, keepalive=0,
+    def __init__(self, client_id, server, port=0, user=None, password=None, keepalive=60,
                  ssl=False, ssl_params={}):
         if port == 0:
             port = 8883 if ssl else 1883


### PR DESCRIPTION
Hi there,

Mosquitto 2.0.12 started honoring `max_keepalive` for MQTT v3 connections in order to improve the situation re. [CVE-2020-13849](https://nvd.nist.gov/vuln/detail/CVE-2020-13849). See also https://github.com/hiveeyes/terkin-datalogger/pull/97#issuecomment-915584984.

So, this patch now uses 60 seconds as a default keepalive setting.

With kind regards,
Andreas.